### PR TITLE
Disable temporarily db update scheduling

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -1,7 +1,7 @@
 name: fetch-data
 on:
-  schedule:
-    - cron: "0 1 * * *" # run at 1 AM UTC
+#  schedule:
+#    - cron: "0 1 * * *" # run at 1 AM UTC
   workflow_dispatch:
   repository_dispatch:
 


### PR DESCRIPTION
Disable temporarily db update scheduling to avoid spam notifications in Slack channel.
