### PR TITLE
Fix image leaking over the text

### DIFF
--- a/components/pages/Homepage/EventCard.tsx
+++ b/components/pages/Homepage/EventCard.tsx
@@ -81,7 +81,7 @@ export const EventCard = ({ event }: EventCardProps) => {
             We skip next/image for now to be able to export fully static build.
             If image optimization is needed, we can think of alternative deployment solutions.
          */}
-        <img src="https://picsum.photos/200" alt="" width={200} height={200} />
+        <img src="https://picsum.photos/200" alt="" />
       </div>
       <Time startDateTime={event.startTime} endDateTime={event.endTime} wholeDay={event.wholeDay} />
       <h2>{event.title}</h2>

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -18,7 +18,7 @@
   display: grid;
   align-items: start;
   row-gap: 0.25rem;
-  column-gap: 0.5rem;
+  column-gap: 1rem;
   justify-content: start;
   grid-template-areas:
     "img time"
@@ -41,7 +41,6 @@
 
 .image-container {
   grid-area: img;
-  max-width: 10rem;
   min-width: 8rem;
 }
 


### PR DESCRIPTION
<!-- Remove non-applicable sections -->

## Purpose

This PR fixes the image leaking over the text after switching to use `img` instead of Next's Image. 

We probably need to tweak this once we will have images that are not square.

## Screenshots
From this:
![Screenshot 2022-03-28 at 7 27 25](https://user-images.githubusercontent.com/28345294/160326618-cb394058-a608-490b-bd8f-f2207392f3b5.png)

To this:

![Screenshot 2022-03-28 at 7 26 54](https://user-images.githubusercontent.com/28345294/160326566-0690d0ae-a964-4fdc-8ed5-92e2aec9f008.png)

## How to test

Check that the page looks like the latter screenshot.